### PR TITLE
test: 테스트 재사용성을 확보하기 위해 MockTestHelper클래스 생성

### DIFF
--- a/src/test/java/mju/chatuniv/helper/MockTestHelper.java
+++ b/src/test/java/mju/chatuniv/helper/MockTestHelper.java
@@ -1,0 +1,70 @@
+package mju.chatuniv.helper;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import mju.chatuniv.member.domain.Member;
+import org.apache.http.HttpHeaders;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.util.Date;
+
+public class MockTestHelper {
+
+    private static final String BEARER_ = "Bearer ";
+
+    private final MockMvc mockMvc;
+
+    @Value("${security.jwt.token.secret-key}")
+    private String secretKey;
+
+    @Value("${security.jwt.token.expire-length}")
+    private long validityInMilliseconds;
+
+    public MockTestHelper(final MockMvc mockMvc) {
+        this.mockMvc = mockMvc;
+    }
+
+    public ResultActions createMockRequestWithTokenAndWithoutContent(final MockHttpServletRequestBuilder uriBuilder, final Member member) throws Exception {
+        return mockMvc.perform(uriBuilder
+                .header(HttpHeaders.AUTHORIZATION, BEARER_ + createTokenByMember(member))
+                .contentType(MediaType.APPLICATION_JSON));
+    }
+
+    public ResultActions createMockRequestWithTokenAndContent(final MockHttpServletRequestBuilder uriBuilder, final Member member, final Object object) throws Exception {
+        return mockMvc.perform(uriBuilder
+                .header(HttpHeaders.AUTHORIZATION, BEARER_ + createTokenByMember(member))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(makeJson(object)));
+    }
+
+    private String createTokenByMember(final Member member) {
+        Claims claims = Jwts.claims()
+                .setSubject(member.getEmail());
+
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    private String makeJson(final Object object) {
+        try {
+            return new ObjectMapper().writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
createMockRequestWithTokenAndWithoutContent : 토큰이 있지만, RequestBody가 없는 경우
* 파라미터
    * uri method, url
    * Member
createMockRequestWithTokenAndContent : 토큰과 RequestBody가 있는 경우
* 파라미터
    * uri method, url
    * Member
    * Json으로 Body에 입력할 Object 

Co-authored-by: sosow0212 <sosow0212@naver.com>

 Co-authored-by: kimtaesoo99 <kimtaesoo7@naver.com>

 Co-authored-by: eom-tae-in <eti0728@daum.net>