### PR TITLE
refactor: 기존 응답 헤더에 채팅방 id값을 담아주는 방식을 응답 body에 담아주는 방식으로 변경

### DIFF
--- a/src/docs/asciidoc/chat.adoc
+++ b/src/docs/asciidoc/chat.adoc
@@ -28,7 +28,7 @@ include::{snippets}/chat-controller-unit-test/create_new_chatting_room/http-requ
 
 ==== 응답
 
-include::{snippets}/chat-controller-unit-test/create_new_chatting_room/http-response.adoc[]
+include::{snippets}/chat-controller-unit-test/create_new_chatting_room/response-fields.adoc[]
 
 === 기존 채팅방 입장
 

--- a/src/main/java/mju/chatuniv/chat/controller/ChatController.java
+++ b/src/main/java/mju/chatuniv/chat/controller/ChatController.java
@@ -1,6 +1,9 @@
 package mju.chatuniv.chat.controller;
 
+import java.util.List;
+import javax.validation.Valid;
 import mju.chatuniv.auth.support.JwtLogin;
+import mju.chatuniv.chat.controller.dto.ChatResponse;
 import mju.chatuniv.chat.controller.dto.ChatRoomsSimpleResponse;
 import mju.chatuniv.chat.controller.dto.ConversationAllResponse;
 import mju.chatuniv.chat.controller.dto.ConversationResponse;
@@ -12,6 +15,7 @@ import mju.chatuniv.chat.service.ChatService;
 import mju.chatuniv.chat.service.dto.chat.ChatPromptRequest;
 import mju.chatuniv.chat.service.dto.chat.ChattingHistoryResponse;
 import mju.chatuniv.member.domain.Member;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,10 +24,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.validation.Valid;
-import java.net.URI;
-import java.util.List;
 
 @RequestMapping("/api/chats")
 @RestController
@@ -46,10 +46,11 @@ public class ChatController {
     }
 
     @PostMapping
-    public ResponseEntity<Void> makeChattingRoom(@JwtLogin final Member member) {
+    public ResponseEntity<ChatResponse> makeChattingRoom(@JwtLogin final Member member) {
         Long chatId = chatService.createNewChattingRoom(member);
-        return ResponseEntity.created(URI.create("/chats/" + chatId))
-                .build();
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ChatResponse.from(chatId));
     }
 
     @GetMapping("/{chatId}")

--- a/src/main/java/mju/chatuniv/chat/controller/dto/ChatResponse.java
+++ b/src/main/java/mju/chatuniv/chat/controller/dto/ChatResponse.java
@@ -1,0 +1,18 @@
+package mju.chatuniv.chat.controller.dto;
+
+public class ChatResponse {
+
+    private final Long chatId;
+
+    private ChatResponse(final Long chatId) {
+        this.chatId = chatId;
+    }
+
+    public static ChatResponse from(final Long chatId) {
+        return new ChatResponse(chatId);
+    }
+
+    public Long getChatId() {
+        return chatId;
+    }
+}

--- a/src/test/java/mju/chatuniv/chat/controller/ChatControllerIntegrationTest.java
+++ b/src/test/java/mju/chatuniv/chat/controller/ChatControllerIntegrationTest.java
@@ -60,7 +60,7 @@ class ChatControllerIntegrationTest extends IntegrationTest {
         // then
         assertAll(
                 () -> assertThat(result.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
-                () -> assertThat(result.header("Location")).isEqualTo("/chats/1")
+                () -> assertThat(result.body().jsonPath().getLong("chatId")).isEqualTo(1L)
         );
     }
 

--- a/src/test/java/mju/chatuniv/chat/controller/ChatControllerUnitTest.java
+++ b/src/test/java/mju/chatuniv/chat/controller/ChatControllerUnitTest.java
@@ -1,6 +1,10 @@
 package mju.chatuniv.chat.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.LongStream;
 import mju.chatuniv.auth.service.JwtAuthService;
 import mju.chatuniv.chat.domain.chat.Chat;
 import mju.chatuniv.chat.domain.chat.Conversation;
@@ -25,11 +29,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.LongStream;
-
 import static mju.chatuniv.fixture.chat.ConversationFixture.createConversation;
 import static mju.chatuniv.helper.RestDocsHelper.customDocument;
 import static org.mockito.ArgumentMatchers.any;
@@ -39,7 +38,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -118,8 +116,8 @@ class ChatControllerUnitTest {
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("로그인 후 제공되는 Bearer 토큰")
                         ),
-                        responseHeaders(
-                                headerWithName("Location").description("새로 생성된 채팅방 ID")
+                        responseFields(
+                                fieldWithPath("chatId").description("채팅 ID")
                         )
                 ));
     }


### PR DESCRIPTION
- [x]  기존 응답 헤더에 채팅방 id값을 담아주는 방식을 응답 body에 담아주는 방식으로 변경